### PR TITLE
Enable integer_atomics feature for Atomic*128

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ derive = ["dep:const-type-layout-derive"]
 serde = ["dep:serde"]
 
 impl-atomics = []
+impl-atomics-128 = ["impl-atomics"]
 impl-never = []
 impl-sync-exclusive = []
 impl-sync-unsafe-cell = []

--- a/src/impls/core/sync/atomic.rs
+++ b/src/impls/core/sync/atomic.rs
@@ -41,7 +41,11 @@ impl_atomic_int_layout! {
     AtomicI8 (1:"8") => i8 => 0, AtomicI16 (2:"16") => i16 => 0,
     AtomicI32 (4:"32") => i32 => 0, AtomicI64 (8:"64") => i64 => 0,
     AtomicU8 (1:"8") => u8 => 0, AtomicU16 (2:"16") => u16 => 0,
-    AtomicU32 (4:"32") => u32 => 0, AtomicU64 (8:"64") => u64 => 0,
+    AtomicU32 (4:"32") => u32 => 0, AtomicU64 (8:"64") => u64 => 0
+}
+
+#[cfg(feature = "impl-atomics-128")]
+impl_atomic_int_layout! {
     AtomicI128 (16:"128") => i128 => 0, AtomicU128 (16:"128") => u128 => 0
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,10 +136,7 @@ r#"TypeLayoutInfo {
 // optional feature-gated features
 // https://github.com/rust-lang/rust/issues/94039
 #![cfg_attr(feature = "impl-atomics", feature(cfg_target_has_atomic))]
-#![cfg_attr(
-    all(feature = "impl-atomics", target_has_atomic_load_store = "128"),
-    feature(integer_atomics)
-)]
+#![cfg_attr(feature = "impl-atomics-128", feature(integer_atomics))]
 #![cfg_attr(feature = "impl-never", feature(never_type))]
 #![cfg_attr(feature = "impl-sync-exclusive", feature(exclusive_wrapper))]
 #![cfg_attr(feature = "impl-sync-unsafe-cell", feature(sync_unsafe_cell))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,10 @@ r#"TypeLayoutInfo {
 // optional feature-gated features
 // https://github.com/rust-lang/rust/issues/94039
 #![cfg_attr(feature = "impl-atomics", feature(cfg_target_has_atomic))]
-#![cfg_attr(feature = "impl-atomics-128", feature(integer_atomics))]
+#![cfg_attr(
+    all(feature = "impl-atomics-128", target_has_atomic = "128"),
+    feature(integer_atomics)
+)]
 #![cfg_attr(feature = "impl-never", feature(never_type))]
 #![cfg_attr(feature = "impl-sync-exclusive", feature(exclusive_wrapper))]
 #![cfg_attr(feature = "impl-sync-unsafe-cell", feature(sync_unsafe_cell))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,11 @@ r#"TypeLayoutInfo {
 #![cfg_attr(doc, feature(doc_auto_cfg))]
 // optional feature-gated features
 // https://github.com/rust-lang/rust/issues/94039
-#![cfg_attr(feature = "impl-atomics", feature(cfg_target_has_atomic))]
+#![feature(cfg_target_has_atomic)]
+#![cfg_attr(
+    all(feature = "impl-atomics", target_has_atomic_load_store = "128"),
+    feature(integer_atomics)
+)]
 #![cfg_attr(feature = "impl-never", feature(never_type))]
 #![cfg_attr(feature = "impl-sync-exclusive", feature(exclusive_wrapper))]
 #![cfg_attr(feature = "impl-sync-unsafe-cell", feature(sync_unsafe_cell))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ r#"TypeLayoutInfo {
 #![cfg_attr(doc, feature(doc_auto_cfg))]
 // optional feature-gated features
 // https://github.com/rust-lang/rust/issues/94039
-#![feature(cfg_target_has_atomic)]
+#![cfg_attr(feature = "impl-atomics", feature(cfg_target_has_atomic))]
 #![cfg_attr(
     all(feature = "impl-atomics", target_has_atomic_load_store = "128"),
     feature(integer_atomics)


### PR DESCRIPTION
Proposing this change as it fixed the build of rust-cuda for me on windows with rustc `channel = "nightly-2024-07-21"`, though I am not sure if there is a more correct way to solve this.